### PR TITLE
Unmount before exit

### DIFF
--- a/src/build.sh
+++ b/src/build.sh
@@ -10,8 +10,8 @@ export SCRIPT_DIR="$(dirname "$(readlink -f "$0")")"
 source $SCRIPT_DIR/shared.sh
 source $SCRIPT_DIR/args.sh
 
-function exit_on_exit() {
-    print_ok "Exit on exit..."
+function action_on_exit() {
+    print_ok "Action on exit..."
     ## Do something before exit.
     sleep 2
     umount_on_exit
@@ -25,7 +25,7 @@ function bind_signal() {
     ## * `help trap`
     ##
     print_ok "Bind signal..."
-    trap exit_on_exit EXIT
+    trap action_on_exit EXIT
     judge "Bind signal"
 }
 

--- a/src/build.sh
+++ b/src/build.sh
@@ -10,6 +10,34 @@ export SCRIPT_DIR="$(dirname "$(readlink -f "$0")")"
 source $SCRIPT_DIR/shared.sh
 source $SCRIPT_DIR/args.sh
 
+function exit_on_exit() {
+    print_ok "Exit on exit..."
+    ## Do something before exit.
+    sleep 2
+    umount_on_exit
+    sleep 2
+    exit 0
+}
+
+function bind_signal() {
+    ##
+    ## * [man 1 bash](https://manpages.debian.org/stable/bash/bash.1.en.html)
+    ## * `help trap`
+    ##
+    print_ok "Bind signal..."
+    trap exit_on_exit EXIT
+    judge "Bind signal"
+}
+
+function umount_on_exit() {
+    print_ok "Umount before exit..."
+    sudo umount new_building_os/dev || sudo umount -lf new_building_os/dev || true
+    sudo umount new_building_os/run || sudo umount -lf new_building_os/run || true
+    sudo umount new_building_os/proc || sudo umount -lf new_building_os/proc || true
+    sudo umount new_building_os/sys || sudo umount -lf new_building_os/sys || true
+    judge "Umount before exit"
+}
+
 function check_host() {
 
     local os_ver
@@ -337,6 +365,7 @@ EOF
 
 # =============   main  ================
 cd $SCRIPT_DIR
+bind_signal
 check_host
 clean
 setup_host


### PR DESCRIPTION
根據您在[另一個討論串](https://github.com/samwhelp/anduinos-iso-builder-remix/issues/1#issuecomment-2876562147)提到的議題。

這個「Pull Request」，加入一個「機制」，

在「製作ISO」的程式離開時，會再「`umount`」一次，

這樣應該可以大幅降低，在還沒有「`umount`」前，就先刪除「`new_building_os`」的機率。

您不見得要合併，

只是提供相關的程式碼，讓您了解相關的實作，

您也可以了解後，重新撰寫您自己的實作。

以上提供參考。

報告完畢。




## 如何測試

* 程式執行時，您可以按下「`Ctrl + c`」來中斷程式
* 或是刻意寫一個會出錯的段落，測試出錯後，是否會跑到那段「`umount`」的程式碼。




## Manpage

* [man 1 bash](https://manpages.debian.org/stable/bash/bash.1.en.html)
* `help trap`

> 可以用「`trap on EXIT`」或「`trap on ERR`」或「[SIGNALS](https://manpages.debian.org/stable/bash/bash.1.en.html#SIGNALS)」當作關鍵字查詢
