### PR TITLE
Add Firefox mod installation option and optimize build

### DIFF
--- a/src/args.sh
+++ b/src/args.sh
@@ -133,6 +133,10 @@ if [[ "$FIREFOX_LOCALE_PACKAGE" != "" && "$FIREFOX_PROVIDER" != "deb" ]]; then
     exit 1
 fi
 
+# Whether to install the Firefox mod
+INSTALL_FIREFOX_MOD=${INSTALL_FIREFOX_MOD:-true}
+
+
 #============================
 # Input method configuration
 #============================

--- a/src/build.sh
+++ b/src/build.sh
@@ -90,6 +90,8 @@ function run_chroot() {
     print_warn "   The following will run in chroot ENV!"
     print_warn "============================================"
     sudo chroot new_building_os /usr/bin/env DEBIAN_FRONTEND=${DEBIAN_FRONTEND:-readline} /root/mods/install_all_mods.sh -
+    sudo chroot new_building_os apt clean
+    sudo chroot new_building_os rm -rf /var/log/*
     print_warn "============================================"
     print_warn "   chroot ENV execution completed!"
     print_warn "============================================"
@@ -187,7 +189,7 @@ EOF
     sudo mksquashfs new_building_os image/casper/filesystem.squashfs \
         -noappend -no-duplicates -no-recovery \
         -wildcards -b 1M \
-        -comp zstd -Xcompression-level 19 \
+        -comp zstd -Xcompression-level 10 \
         -e "var/cache/apt/archives/*" \
         -e "root/*" \
         -e "root/.*" \

--- a/src/mods/install_all_mods.sh
+++ b/src/mods/install_all_mods.sh
@@ -33,3 +33,8 @@ for mod in "$SCRIPT_DIR"/*; do
         )
     fi
 done
+
+# Install Firefox
+if [ "$INSTALL_FIREFOX_MOD" = "true" ]; then
+    $SCRIPT_DIR/18-firefox-mod/install.sh
+fi


### PR DESCRIPTION
Optimize ISO build process and clean up temporary files

- Reduced zstd compression level from 19 to 10 in `mksquashfs` command within `src/build.sh` to speed up ISO image creation.
- Added `apt clean` and `rm -rf /var/log/*` commands to the `run_chroot` function in `src/build.sh` to clear package cache and temporary logs after module installation.